### PR TITLE
GH4: Update to .NET 4.6.1, Update Cake to 0.23

### DIFF
--- a/nuspec/nuget/Cake.Grunt.nuspec
+++ b/nuspec/nuget/Cake.Grunt.nuspec
@@ -14,8 +14,8 @@
     <tags>Cake, Script, Build, Grunt, Addin</tags>
   </metadata>
   <files>
-    <file src="Cake.Grunt.dll" target="lib\net45" />
-    <file src="Cake.Grunt.pdb" target="lib\net45" />
-    <file src="Cake.Grunt.xml" target="lib\net45" />
+    <file src="Cake.Grunt.dll" target="lib\net461" />
+    <file src="Cake.Grunt.pdb" target="lib\net461" />
+    <file src="Cake.Grunt.xml" target="lib\net461" />
   </files>
 </package>

--- a/src/Cake.Grunt.Tests/Cake.Grunt.Tests.csproj
+++ b/src/Cake.Grunt.Tests/Cake.Grunt.Tests.csproj
@@ -34,11 +34,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.18.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.18.0\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.23.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.23.0\lib\net46\Cake.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Cake.Testing, Version=0.18.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Testing.0.18.0\lib\net45\Cake.Testing.dll</HintPath>
+    <Reference Include="Cake.Testing, Version=0.23.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Testing.0.23.0\lib\net46\Cake.Testing.dll</HintPath>
     </Reference>
     <Reference Include="Shouldly, Version=2.8.2.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
       <HintPath>..\packages\Shouldly.2.8.2\lib\net451\Shouldly.dll</HintPath>

--- a/src/Cake.Grunt.Tests/Cake.Grunt.Tests.csproj
+++ b/src/Cake.Grunt.Tests/Cake.Grunt.Tests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cake.Grunt.Tests</RootNamespace>
     <AssemblyName>Cake.Grunt.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>
@@ -36,15 +36,12 @@
   <ItemGroup>
     <Reference Include="Cake.Core, Version=0.18.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Cake.Core.0.18.0\lib\net45\Cake.Core.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Cake.Testing, Version=0.18.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Cake.Testing.0.18.0\lib\net45\Cake.Testing.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Shouldly, Version=2.8.2.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
-      <HintPath>..\packages\Shouldly.2.8.2\lib\net40\Shouldly.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Shouldly.2.8.2\lib\net451\Shouldly.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -56,15 +53,12 @@
     <Reference Include="System.Xml" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
-      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Cake.Grunt.Tests/app.config
+++ b/src/Cake.Grunt.Tests/app.config
@@ -8,4 +8,7 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
+  </startup>
 </configuration>

--- a/src/Cake.Grunt.Tests/packages.config
+++ b/src/Cake.Grunt.Tests/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.18.0" targetFramework="net45" />
-  <package id="Cake.Testing" version="0.18.0" targetFramework="net45" />
-  <package id="Shouldly" version="2.8.2" targetFramework="net45" />
-  <package id="xunit" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
+  <package id="Cake.Core" version="0.18.0" targetFramework="net461" />
+  <package id="Cake.Testing" version="0.18.0" targetFramework="net461" />
+  <package id="Shouldly" version="2.8.2" targetFramework="net461" />
+  <package id="xunit" version="2.0.0" targetFramework="net461" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net461" />
+  <package id="xunit.assert" version="2.0.0" targetFramework="net461" />
+  <package id="xunit.core" version="2.0.0" targetFramework="net461" />
+  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net461" />
 </packages>

--- a/src/Cake.Grunt.Tests/packages.config
+++ b/src/Cake.Grunt.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.18.0" targetFramework="net461" />
-  <package id="Cake.Testing" version="0.18.0" targetFramework="net461" />
+  <package id="Cake.Core" version="0.23.0" targetFramework="net461" />
+  <package id="Cake.Testing" version="0.23.0" targetFramework="net461" />
   <package id="Shouldly" version="2.8.2" targetFramework="net461" />
   <package id="xunit" version="2.0.0" targetFramework="net461" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net461" />

--- a/src/Cake.Grunt/Cake.Grunt.csproj
+++ b/src/Cake.Grunt/Cake.Grunt.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cake.Grunt</RootNamespace>
     <AssemblyName>Cake.Grunt</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -36,7 +36,6 @@
   <ItemGroup>
     <Reference Include="Cake.Core, Version=0.18.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Cake.Core.0.18.0\lib\net45\Cake.Core.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Cake.Grunt/Cake.Grunt.csproj
+++ b/src/Cake.Grunt/Cake.Grunt.csproj
@@ -34,8 +34,8 @@
     <DocumentationFile>Cake.Grunt.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.18.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.18.0\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.23.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.23.0\lib\net46\Cake.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Cake.Grunt/packages.config
+++ b/src/Cake.Grunt/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.18.0" targetFramework="net461" />
+  <package id="Cake.Core" version="0.23.0" targetFramework="net461" />
 </packages>

--- a/src/Cake.Grunt/packages.config
+++ b/src/Cake.Grunt/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.18.0" targetFramework="net45" />
+  <package id="Cake.Core" version="0.18.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
This updates .NET to 4.6.1 and Cake to 0.23.0 to allow compatibility with the latest version of Cake to address GH-4
I've left the commits for each task separate, I can squash easily enough if that's preferred.